### PR TITLE
111 fix timer display fronted for joined users

### DIFF
--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -45,6 +45,7 @@ interface JoinSessionResponse {
   sessionId: number;
   sessionToken: string;
   hostId: number;
+  joinedUsers?: number; // Optional, for frontend logic
 }
 
 // Generate player options for the Select component
@@ -159,54 +160,8 @@ const Play: React.FC = () => {
     return;
   }
 
-  const payload: SessionPutDTO = {
-    id: userId,
-    token,
-  };
-
-  try {
-    const session = await apiService.put<JoinSessionResponse>(`/session/${trimmedCode}`, payload);
-
-    // needed for later checks on voting page
-    localStorage.setItem("hostId", session.hostId.toString());
-
-    // Optional local hint only (not global), implement in backend for full functionality
-    const key = `joinedUsers:${session.sessionCode}`;
-    const current = Number(sessionStorage.getItem(key) ?? "1");
-    sessionStorage.setItem(key, String(current + 1));
-
-    // mark participant as already joined so waiting-room verify does NOT join again
-    sessionStorage.setItem(
-      `joinedSession:${session.sessionCode}`,
-      `${userId}:${token}`,
-    );
-
-    messageApi.success("Session joined successfully!");
-    router.push(`/session/${session.sessionCode}`);
-  } catch (error) {
-    const err = error as { status?: number };
-
-    if (err.status === 404) {
-      joinForm.setFields([
-        {
-          name: "sessionCode",
-          errors: ["Session not found. Check the code and try again."],
-        },
-      ]);
-      return;
-    }
-
-    console.error("Join session error:", error);
-    joinForm.setFields([
-      {
-        name: "sessionCode",
-        errors: ["Failed to join session. Please try again."],
-      },
-    ]);
-
-    localStorage.removeItem("hostId");
-    sessionStorage.removeItem(`joinedSession:${trimmedCode}`);
-  }
+  // Navigate to session page; the session page will handle joining if needed
+  router.push(`/session/${trimmedCode}`);
 };
 
   if (!isAuthorized) {

--- a/app/session/[sessionCode]/page.tsx
+++ b/app/session/[sessionCode]/page.tsx
@@ -140,6 +140,7 @@ const SessionWaitingRoom: React.FC = () => {
       if (joinedSessionMarker === `${parsedUserId}:${token}`) {
         const cachedSessionCode = routeSessionCode;
         setSessionCode(cachedSessionCode);
+        setJoinedUsers(Number(sessionStorage.getItem(`joinedUsers:${cachedSessionCode}`) ?? "1"));
         setIsValid(true);
         setIsLoading(false);
         return;

--- a/app/session/[sessionCode]/page.tsx
+++ b/app/session/[sessionCode]/page.tsx
@@ -20,6 +20,7 @@ interface SessionResponse {
   sessionCode: string;
   sessionToken: string;
   hostId: number;
+  joinedUsers?: number;
 }
 
 interface FilterFormValues {
@@ -131,6 +132,7 @@ const SessionWaitingRoom: React.FC = () => {
       const joinedSessionKey = `joinedSession:${routeSessionCode}`;
       const joinedSessionMarker = sessionStorage.getItem(joinedSessionKey);
 
+      // is the user authenticated and is there a session code in the route
       if (!token || Number.isNaN(parsedUserId) || !routeSessionCode) {
         sessionStorage.setItem("redirectMessage", "Please log in to use this service.");
         router.replace("/login");
@@ -146,6 +148,7 @@ const SessionWaitingRoom: React.FC = () => {
         return;
       }
 
+      // handles the case where user would refresh the page
       const storedHostId = parseStorageValue<string | number>(localStorage.getItem("hostId"));
       const storedSessionCode = localStorage.getItem("sessionCode");
       if (
@@ -172,13 +175,13 @@ const SessionWaitingRoom: React.FC = () => {
 
         setSessionCode(session.sessionCode);
         setIsHost(session.hostId === parsedUserId);
-        //mark session as joined in sessionStorage, User can join one time
+        localStorage.setItem("hostId", session.hostId.toString());
         sessionStorage.setItem(joinedSessionKey, `${parsedUserId}:${token}`);
-        // Local hint only (not global)
-        const key = `joinedUsers:${session.sessionCode}`;
-        const hinted = Number(sessionStorage.getItem(key) ?? "1");
-        setJoinedUsers(hinted);
 
+        const actualCount = session.joinedUsers ?? 1;
+        sessionStorage.setItem(`joinedUsers:${session.sessionCode}`, String(actualCount));
+        setJoinedUsers(actualCount);
+        
         setIsValid(true);
       } catch (error) {
         console.error("Failed to verify session access:", error);
@@ -196,7 +199,7 @@ const SessionWaitingRoom: React.FC = () => {
     const apiDomain = getApiDomain().replace(/\/$/, "");
     return `${apiDomain}/gs-guide-websocket`;
   };
-
+  // only afrer successful session access is the user able to subscribe to websockets for real-time updates in the lobby and session
   useEffect(() => {
     if (!isValid || !sessionCode) {
       return;

--- a/app/session/[sessionCode]/vote/page.tsx
+++ b/app/session/[sessionCode]/vote/page.tsx
@@ -60,6 +60,7 @@ const VotePage: React.FC = () => {
   const [messageApi, contextHolder] = message.useMessage();
   const [isHost, setIsHost] = useState(false);
   const isAdvancingRef = useRef(false);
+  const lastMovieIdRef = useRef<number | null>(null);
 
   const getMovieId = (m: MovieGetDTO | (MovieGetDTO & { id?: number }) | null): number | null => {
     if (!m) return null;
@@ -202,12 +203,20 @@ const VotePage: React.FC = () => {
 
   // Auto-advance to next movie after timePerRound seconds
   useEffect(() => {
-    if (!movie || isLoading || !isHost) return;
+    if (!movie || isLoading) return;
     if (!timePerRound || timePerRound <= 0) return;
 
+    const currentMovieId = getMovieId(movie);
+    if (currentMovieId === lastMovieIdRef.current) return;
+
+    lastMovieIdRef.current = currentMovieId;
     setTimeRemaining(timePerRound);
-    
-    //manual countdown ;), possible to display remaining time to users etc...
+  }, [movie, isLoading, timePerRound]);
+
+  // Start countdown timer
+  useEffect(() => {
+    if (!timePerRound || timePerRound <= 0) return;
+
     const countdownInterval = setInterval(() => {
       setTimeRemaining((prev) => {
         if (prev <= 1) {
@@ -220,7 +229,7 @@ const VotePage: React.FC = () => {
     }, 1000);
 
     return () => clearInterval(countdownInterval);
-  }, [movie, isHost, isLoading, timePerRound]);
+  }, [timePerRound]);
 
   const advanceToNextMovie = async () => {
     if (!isHost || isAdvancingRef.current) {
@@ -325,6 +334,10 @@ const VotePage: React.FC = () => {
       try {
         const currentMovie = await apiService.get<MovieGetDTO>(`/session/${routeSessionCode}/current`);
         if (cancelled || !currentMovie) return;
+
+        const currentMovieId = getMovieId(currentMovie);
+        const existingMovieId = getMovieId(movie);
+        if (currentMovieId === existingMovieId) return; // No change, don't update
 
         setMovie(currentMovie);
         sessionStorage.setItem(`currentMovie:${routeSessionCode}`, JSON.stringify(currentMovie));


### PR DESCRIPTION
#111 

Implemented the following things:

- Timer visibility for all users: hosts and joined players
- Enable synchronous display of current number of joined users for the host
- Enable synchronous display of all joined users over users having joined