### PR TITLE
#122 enable redirection for no vote

### DIFF
--- a/app/session/[sessionCode]/vote/page.tsx
+++ b/app/session/[sessionCode]/vote/page.tsx
@@ -330,7 +330,7 @@ useEffect(() => {
   //should prevent multiples votes for same movie 
   const currentMovieId = getMovieId(movie);
   const hasVotedCurrentMovie = currentMovieId ? votedMovieIds.includes(currentMovieId) : false;
-  const isWaitingForNextMovie = hasVotedCurrentMovie && !isSubmittingVote;
+  const isWaitingForNextMovie = (hasVotedCurrentMovie || timeRemaining <= 0) && !isSubmittingVote;
 
   useEffect(() => {
     if (!routeSessionCode || isHost || !isWaitingForNextMovie) {


### PR DESCRIPTION
#122 

Now, when a user forget to enter a vote or runs out of time, the user still gets the next movie and is not stuck in the movie page from before