### PR TITLE
Added front end for history. managed displaying of movie and added a …

### DIFF
--- a/app/history/[historyId]/page.tsx
+++ b/app/history/[historyId]/page.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import Navbar from "@/components/Navbar";
+import { useApi } from "@/hooks/useApi";
+import { parseStorageValue } from "@/utils/storage";
+import { ArrowLeftOutlined } from "@ant-design/icons";
+import { Button, Card, Typography, message } from "antd";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+const { Title, Text, Paragraph } = Typography;
+
+interface HistoryMovieEntry {
+  movieId: number;
+  score: number;
+}
+
+interface HistoryDetail {
+  historyId: number;
+  sessionName: string;
+  sessionCode: string;
+  joinedUsers: number;
+  creationDate: string;
+  movies: HistoryMovieEntry[];
+}
+
+interface MovieInfo {
+  movieId: number;
+  title: string;
+  description?: string;
+  posterPath?: string;
+  rating?: number;
+  releaseDate?: string;
+  genres?: string[];
+}
+
+const HistoryDetailPage: React.FC = () => {
+  const apiService = useApi();
+  const router = useRouter();
+  const params = useParams();
+  const historyId = params.historyId as string;
+
+  const [isAuthorized, setIsAuthorized] = useState(false);
+  const [history, setHistory] = useState<HistoryDetail | null>(null);
+  const [movieDetails, setMovieDetails] = useState<Map<number, MovieInfo>>(new Map());
+  const [messageApi, contextHolder] = message.useMessage();
+
+  const fetchHistory = useCallback(async () => {
+    const userId = parseStorageValue<string | number>(localStorage.getItem("userId"));
+    if (!userId || !historyId) return;
+
+    try {
+      const data = await apiService.get<HistoryDetail>(`/users/${userId}/histories/${historyId}`);
+      setHistory(data);
+
+      // Fetch movie details for each movie in the history
+      const details = new Map<number, MovieInfo>();
+      const movieFetches = data.movies.map(async (entry) => {
+        try {
+          const movie = await apiService.get<MovieInfo>(`/movies/${entry.movieId}`);
+          details.set(entry.movieId, movie);
+        } catch (err) {
+          console.error(`Failed to fetch movie ${entry.movieId}:`, err);
+        }
+      });
+
+      await Promise.all(movieFetches);
+      setMovieDetails(new Map(details));
+    } catch (error) {
+      console.error("Failed to fetch history detail:", error);
+      messageApi.error("Failed to load history details.");
+      router.replace("/history");
+    }
+  }, [apiService, historyId, messageApi, router]);
+
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    const userId = localStorage.getItem("userId");
+
+    if (!token || !userId || token === "" || userId === "") {
+      sessionStorage.setItem("redirectMessage", "Please log in to use this service.");
+      router.replace("/login");
+      return;
+    }
+
+    setIsAuthorized(true);
+    void fetchHistory();
+  }, [router, fetchHistory]);
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  };
+
+  const getPosterUrl = (posterPath?: string): string => {
+    if (!posterPath) return "";
+    if (posterPath.startsWith("http")) return posterPath;
+    return `https://image.tmdb.org/t/p/w500${posterPath}`;
+  };
+
+  if (!isAuthorized || !history) {
+    return null;
+  }
+
+  const moviesSortedByScore = [...history.movies].sort((a, b) => b.score - a.score);
+
+  return (
+    <>
+      {contextHolder}
+      <div className="page-with-nav">
+        <Navbar />
+
+        <div className="results-container">
+          <div className="results-header-row">
+            <div className="results-header">
+              <Title level={2} style={{ marginBottom: 0 }}>
+                {history.sessionName}
+              </Title>
+              <Text type="secondary" style={{ fontSize: 14 }}>
+                {formatDate(history.creationDate)} • {history.joinedUsers} player{history.joinedUsers !== 1 ? "s" : ""} • {history.movies.length} movie{history.movies.length !== 1 ? "s" : ""}
+              </Text>
+            </div>
+
+            <Button
+              size="large"
+              icon={<ArrowLeftOutlined />}
+              className="history-back-btn"
+              onClick={() => router.push("/history")}
+            >
+              Back to History
+            </Button>
+          </div>
+
+          <div className="results-list">
+            {moviesSortedByScore.length === 0 ? (
+              <div className="results-empty">
+                <Text>No movies in this session.</Text>
+              </div>
+            ) : (
+              moviesSortedByScore.map((entry) => {
+                const movie = movieDetails.get(entry.movieId);
+                const posterUrl = movie ? getPosterUrl(movie.posterPath) : "";
+                const score = entry.score ?? 0;
+
+                return (
+                  <Card key={entry.movieId} className="result-item-card">
+                    <div className="result-item-content">
+                      <div className="result-item-poster">
+                        {posterUrl ? (
+                          <img
+                            src={posterUrl}
+                            alt={movie?.title ?? `Movie ${entry.movieId}`}
+                            className="result-item-image"
+                          />
+                        ) : (
+                          <div className="result-item-placeholder">
+                            <Text>No poster</Text>
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="result-item-info">
+                        <Title level={4} style={{ marginBottom: 8 }}>
+                          {movie?.title ?? `Movie #${entry.movieId}`}
+                        </Title>
+
+                        <div className="result-item-tags">
+                          <div className="vote-info">
+                            <Paragraph className="vote-description" style={{ marginBottom: 10 }}>
+                              {movie?.description ?? "No description available."}
+                            </Paragraph>
+
+                            <div className="result-tags-row">
+                              <span className="result-tag">
+                                {movie?.rating ? `Rating: ${movie.rating.toFixed(1)}` : "No rating"}
+                              </span>
+                              <span className="result-tag">
+                                {movie?.releaseDate ? movie.releaseDate.slice(0, 4) : "Unknown year"}
+                              </span>
+                            </div>
+
+                            {movie?.genres && movie.genres.length > 0 && (
+                              <div className="result-tags-row">
+                                {movie.genres.map((genre) => (
+                                  <span key={genre} className="result-tag">
+                                    {genre}
+                                  </span>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="result-item-score">
+                        <div
+                          className="score-badge"
+                          style={{
+                            backgroundColor:
+                              score > 0 ? "#72f681" : score < 0 ? "#ff4d4f" : "#d9d9d9",
+                          }}
+                        >
+                          {score > 0 ? "+" : ""}
+                          {score}
+                        </div>
+                      </div>
+                    </div>
+                  </Card>
+                );
+              })
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default HistoryDetailPage;

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,55 +1,159 @@
 "use client";
 
 import Navbar from "@/components/Navbar";
-import { Card, Typography } from "antd";
+import { useApi } from "@/hooks/useApi";
+import { parseStorageValue } from "@/utils/storage";
+import { DeleteOutlined, RightOutlined } from "@ant-design/icons";
+import { Button, Card, Modal, Typography, message } from "antd";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-const { Title, Paragraph } = Typography;
+const { Title, Paragraph, Text } = Typography;
+
+interface HistoryEntry {
+  historyId: number;
+  sessionName: string;
+  sessionCode: string;
+  joinedUsers: number;
+  creationDate: string;
+  movies: { movieId: number; score: number }[];
+}
 
 const historyDescription =
   "Review your previous sessions and dive into the details of your movie nights. See which movies you and your friends enjoyed, check out the session summaries, and relive the fun moments. Your movie history is just a click away!";
 
 const History: React.FC = () => {
   const [isAuthorized, setIsAuthorized] = useState(false);
+  const [histories, setHistories] = useState<HistoryEntry[]>([]);
+  const [deleteTarget, setDeleteTarget] = useState<HistoryEntry | null>(null);
   const router = useRouter();
+  const apiService = useApi();
+  const [messageApi, contextHolder] = message.useMessage();
 
+  const fetchHistories = useCallback(async () => {
+    const userId = parseStorageValue<string | number>(localStorage.getItem("userId"));
+    if (!userId) return;
+    try {
+      const data = await apiService.get<HistoryEntry[]>(`/users/${userId}/histories`);
+      setHistories(Array.isArray(data) ? data : []);
+    } catch (error) {
+      console.error("Failed to fetch histories:", error);
+      messageApi.error("Failed to load history.");
+    }
+  }, [apiService, messageApi]);
 
   useEffect(() => {
-      const token = localStorage.getItem("token");
-      const userId = localStorage.getItem("userId");
-  
-      if (!token || !userId || token === "" || userId === "") {
-        sessionStorage.setItem("redirectMessage", "Please log in to use this service.");
-        router.replace("/login");
-        return;
-      }
-  
-      setIsAuthorized(true);
+    const token = localStorage.getItem("token");
+    const userId = localStorage.getItem("userId");
 
-  }, [router]);
+    if (!token || !userId || token === "" || userId === "") {
+      sessionStorage.setItem("redirectMessage", "Please log in to use this service.");
+      router.replace("/login");
+      return;
+    }
+
+    setIsAuthorized(true);
+    void fetchHistories();
+  }, [router, fetchHistories]);
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    const userId = parseStorageValue<string | number>(localStorage.getItem("userId"));
+    try {
+      await apiService.delete(`/users/${userId}/histories/${deleteTarget.historyId}`);
+      setHistories((prev) => prev.filter((h) => h.historyId !== deleteTarget.historyId));
+      messageApi.success("History entry deleted.");
+    } catch (error) {
+      console.error("Failed to delete history:", error);
+      messageApi.error("Failed to delete history entry.");
+    } finally {
+      setDeleteTarget(null);
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  };
 
   if (!isAuthorized) {
     return null;
   }
 
   return (
-    <div className="page-with-nav">
+    <>
+      {contextHolder}
+      <div className="page-with-nav">
         <Navbar />
 
         <div className="history-container">
-        <div className="history-intro">
+          <div className="history-intro">
             <Title level={1}>History</Title>
             <Paragraph>{historyDescription}</Paragraph>
+          </div>
+
+          <div className="history-list">
+            {histories.length === 0 ? (
+              <div className="history-empty">
+                <Text>No saved sessions yet. Play a session and save it to see it here!</Text>
+              </div>
+            ) : (
+              histories.map((entry) => (
+                <Card
+                  key={entry.historyId}
+                  className="history-entry-card"
+                  onClick={() => router.push(`/history/${entry.historyId}`)}
+                >
+                  <div className="history-entry-content">
+                    <div className="history-entry-info">
+                      <Title level={4} style={{ marginBottom: 4 }}>
+                        {entry.sessionName}
+                      </Title>
+                      <div className="history-entry-meta">
+                        <Text type="secondary">
+                          {formatDate(entry.creationDate)} • {entry.joinedUsers} player{entry.joinedUsers !== 1 ? "s" : ""} • {entry.movies.length} movie{entry.movies.length !== 1 ? "s" : ""}
+                        </Text>
+                      </div>
+                    </div>
+                    <div className="history-entry-actions">
+                      <Button
+                        type="text"
+                        danger
+                        icon={<DeleteOutlined />}
+                        className="history-delete-btn"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setDeleteTarget(entry);
+                        }}
+                      />
+                      <RightOutlined className="history-entry-arrow" />
+                    </div>
+                  </div>
+                </Card>
+              ))
+            )}
+          </div>
         </div>
 
-        <div className="history-actions">
-            <Card className="history-action-card">
-            Saved items will be displayed here.
-            </Card>
-        </div>
-        </div>
-    </div>
+        <Modal
+          open={deleteTarget !== null}
+          onCancel={() => setDeleteTarget(null)}
+          onOk={handleDeleteConfirm}
+          title="Delete History Entry"
+          okText="Delete"
+          okButtonProps={{ danger: true }}
+          className="history-delete-modal"
+        >
+          <Paragraph>
+            Are you sure you want to delete the history for session &quot;{deleteTarget?.sessionName}&quot;? This action cannot be undone.
+          </Paragraph>
+        </Modal>
+      </div>
+    </>
   );
 };
 

--- a/app/session/[sessionCode]/results/page.tsx
+++ b/app/session/[sessionCode]/results/page.tsx
@@ -122,8 +122,8 @@ const handleSaveToHistory = async () => {
     const parsedUserId = Number(userIdRaw);
     const historyKey = `historySaved:${routeSessionCode}:${parsedUserId}`;
 
-    // TODO: call backend endpoint later, endpoint name can be changed, just a first idea
-    // await apiService.post(`/users/${parsedUserId}/history`, { sessionCode: routeSessionCode });
+    const token = parseStorageValue<string>(localStorage.getItem("token"));
+    await apiService.post("/histories", { sessionCode: routeSessionCode, token });
 
     localStorage.setItem(historyKey, "true");
     setIsHistorySaved(true);

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -1244,3 +1244,125 @@ hyphens: auto;
   box-shadow: none !important;
   text-align: center;
 }
+
+/* History List Page Styles */
+.history-list {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.history-empty {
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--accent);
+}
+
+.history-entry-card.ant-card {
+  width: 100%;
+  background: var(--card) !important;
+  border: 1px solid var(--secondary) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+  cursor: pointer;
+}
+
+.history-entry-card .ant-card-body {
+  padding: 16px 20px !important;
+}
+
+.history-entry-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.history-entry-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.history-entry-info .ant-typography-title {
+  color: var(--text) !important;
+  font-size: 22px !important;
+  margin-bottom: 4px !important;
+}
+
+.history-entry-meta .ant-typography {
+  color: var(--accent) !important;
+  font-size: 14px !important;
+}
+
+.history-entry-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.history-delete-btn.ant-btn {
+  color: rgba(255, 77, 79, 0.8) !important;
+  font-size: 16px;
+}
+
+.history-entry-arrow {
+  color: var(--accent);
+  font-size: 14px;
+}
+
+/* History Detail Page Styles */
+.history-back-btn.ant-btn {
+  flex: 0 0 auto;
+  align-self: flex-start;
+  margin-top: 8px;
+  min-width: 190px;
+  background: rgba(212, 175, 55, 0.15) !important;
+  border-color: var(--primary-gold) !important;
+  color: var(--primary-gold) !important;
+  height: 46px;
+  padding: 0 22px !important;
+  border-radius: 12px !important;
+  font-weight: 700;
+  font-size: 16px !important;
+}
+
+/* History Delete Modal Styles */
+.history-delete-modal .ant-modal-content {
+  background: var(--card) !important;
+  border: 1px solid var(--secondary) !important;
+}
+
+.history-delete-modal .ant-modal-header {
+  background: var(--card) !important;
+  border-bottom: 1px solid var(--secondary) !important;
+}
+
+.history-delete-modal .ant-modal-title {
+  color: var(--text) !important;
+}
+
+.history-delete-modal .ant-modal-close {
+  color: var(--text) !important;
+}
+
+.history-delete-modal .ant-modal-close:hover {
+  color: var(--primary-gold) !important;
+  background: rgba(212, 175, 55, 0.12) !important;
+}
+
+.history-delete-modal .ant-modal-body .ant-typography {
+  color: var(--text) !important;
+}
+
+.history-delete-modal .ant-modal-footer .ant-btn-default {
+  border-color: var(--secondary) !important;
+  color: var(--text) !important;
+}
+
+.history-delete-modal .ant-modal-footer .ant-btn-default:hover {
+  border-color: var(--accent) !important;
+  color: var(--accent) !important;
+}


### PR DESCRIPTION
- Created **history/{historyid}/page.tsx**. This provides a detailed view of a single saved round result. It is accessed by clicking on a single history entry inside the past games list in /history. Design closely based on the already existing results page. Displays round metadata. 
- Updated **app/history/page.tsx**. After checking for a valid token the page now renders a list of the past saved rounds of the user. The single list entries are clickable and redirect to app/history/[historyId]/page.tsx (siehe oben). It also displays round metadata, such as date, player amount and movie amount. (should refine in M4). Entries have a delete option. 
- **app/session/[sessionCode]/results/page.tsx**. Took the commented out backend endpoint call and made it work. 
- **app/styles/globals.css.** Added the styles for the history entries. 